### PR TITLE
Add int type for options

### DIFF
--- a/brocolito/src/arguments.ts
+++ b/brocolito/src/arguments.ts
@@ -22,7 +22,7 @@ const deriveInfo = <S extends `<${string}${string}>`>(
   const m = match[2]?.substring(1) ?? "string"; // without the collon
   return {
     name: camelize(match[1]) as ArgumentToName<S>,
-    type: m === "string" || m === "file" ? m : m.split("|"),
+    type: m === "string" || m === "file" || m === "int" ? m : m.split("|"),
     multi: !!match[3],
   };
 };
@@ -54,7 +54,7 @@ const deriveOptionInfo = (
   return {
     name,
     short,
-    type: m === "string" || m === "file" ? m : m.split("|"),
+    type: m === "string" || m === "file" || m === "int" ? m : m.split("|"),
     mandatory,
     multi: !!optionTypeMatch[2],
   };

--- a/brocolito/src/brocolito.ts
+++ b/brocolito/src/brocolito.ts
@@ -18,7 +18,7 @@ import pc from "picocolors";
 
 process.on("unhandledRejection", (err) => {
   // in case of unhandled rejections, these are usually expected to be raised to the caller of the CLI.
-  // Hence, we want to make them very minimal but good visible
+  // Hence, we want to make them very minimal but well visible
   const errMsg = String(
     err instanceof Error ? (process.env.DEBUG ? err.stack : err.message) : err,
   );

--- a/brocolito/src/parse.ts
+++ b/brocolito/src/parse.ts
@@ -94,7 +94,7 @@ export const findCommand = (args: string[]): FoundCommand => {
 const _parseArgs = (
   command: Command,
   args: string[],
-): Record<string, string | string[] | undefined> => {
+): Record<string, string | string[] | number | number[] | undefined> => {
   const throwError = (reason: string, remainingArgs?: string[]) => {
     Help.show(command);
     throw new Error(
@@ -112,7 +112,12 @@ The following arguments could not be processed: ${pc.yellow(
   let usedArgs = [...args];
   const result = Object.fromEntries(
     command.args.map(
-      ({ usage, name, type, multi }): [string, string | string[]] => {
+      ({
+        usage,
+        name,
+        type,
+        multi,
+      }): [string, string | string[] | number | number[]] => {
         if (!usedArgs.length) {
           // by default multi args can be empty as well
           return multi ? [name, []] : throwError("Too few arguments given");
@@ -121,17 +126,22 @@ The following arguments could not be processed: ${pc.yellow(
           if (Array.isArray(type) && !type.includes(v)) {
             throw new Error(`Invalid value "${v}" provided for arg ${usage}.`);
           }
+          if (type === "int" && !Number.isInteger(Number(v))) {
+            throw new Error(
+              `Invalid value "${v}" provided for arg ${usage}. Expected an integer.`,
+            );
+          }
         };
         if (!multi) {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const arg = usedArgs.shift()!;
           checkValiditiy(arg);
-          return [name, arg];
+          return [name, type === "int" ? Number(arg) : arg];
         } else {
           const copy = [...usedArgs];
           copy.forEach(checkValiditiy);
           usedArgs = [];
-          return [name, copy];
+          return [name, type === "int" ? copy.map(Number) : copy];
         }
       },
     ),
@@ -143,8 +153,14 @@ The following arguments could not be processed: ${pc.yellow(
 const _parseOptions = (
   command: Command,
   options: ParseResult["values"],
-): Record<string, string[] | string | boolean | undefined> => {
-  const opts: Record<string, string[] | string | boolean | undefined> = {};
+): Record<
+  string,
+  string[] | string | boolean | number | number[] | undefined
+> => {
+  const opts: Record<
+    string,
+    string[] | string | boolean | number | number[] | undefined
+  > = {};
   Object.entries(command.options as Record<string, OptionMeta>).forEach(
     ([camelName, { name, type, mandatory }]) => {
       const value = options[name];
@@ -184,13 +200,19 @@ const _parseOptions = (
               )}`,
             );
           }
+          if (type === "int" && !Number.isInteger(Number(v))) {
+            throw new Error(
+              `Invalid value "${v}" provided for flag --${name}. Expected an integer.`,
+            );
+          }
         };
         if (Array.isArray(value)) {
           value.forEach(checkValiditiy);
-          opts[camelName] = value as string[];
+          opts[camelName] =
+            type === "int" ? value.map(Number) : (value as string[]);
         } else {
           checkValiditiy(value);
-          opts[camelName] = value;
+          opts[camelName] = type === "int" ? Number(value) : value;
         }
       }
     },

--- a/brocolito/src/types.ts
+++ b/brocolito/src/types.ts
@@ -35,9 +35,11 @@ type UnionFromPipes<TType extends string> =
 
 type TypeFromSpec<TSpec extends string> = TSpec extends `${infer T}...`
   ? TypeFromSpec<T>[]
-  : TSpec extends "file" | "string"
-    ? string
-    : UnionFromPipes<TSpec>;
+  : TSpec extends "int"
+    ? number
+    : TSpec extends "file" | "string"
+      ? string
+      : UnionFromPipes<TSpec>;
 
 export type ArgumentToName<S extends string> = SnakeToCamelCase<
   RemoveArgumentType<RemoveArgumentDots<RemoveArgumentBrackets<S>>>
@@ -76,7 +78,7 @@ type Option<OPTIONS, ARGS, TArgState extends ArgStates> = <
 ) => Command<OPTIONS & OptionArg<USAGE>, ARGS, TArgState>;
 
 export type ArgType = {
-  type: "string" | "file" | string[];
+  type: "string" | "file" | "int" | string[];
   multi: boolean;
 } & CompletionOpt;
 

--- a/brocolito/tests/arguments.test.ts
+++ b/brocolito/tests/arguments.test.ts
@@ -24,6 +24,14 @@ describe("arguments", () => {
     { usage: "--foo something", type: "string", name: "foo" },
     { usage: "--foo! something", type: "string", name: "foo", mandatory: true },
     { usage: "--foo! <file>", type: "file", name: "foo", mandatory: true },
+    { usage: "--foo <int>", type: "int", name: "foo" },
+    { usage: "--foo <int...>", type: "int", name: "foo", multi: true },
+    {
+      usage: "--foo! <int>",
+      type: "int",
+      name: "foo",
+      mandatory: true,
+    },
   ])(
     "parses argument info for option with usage '$usage'",
     ({ usage, name, type, mandatory = false, multi = false }) => {
@@ -49,6 +57,8 @@ describe("arguments", () => {
     { usage: "<foo:one|two...>", type: ["one", "two"], multi: true },
     { usage: "<foo:file>", type: "file" },
     { usage: "<foo:file...>", type: "file", multi: true },
+    { usage: "<foo:int>", type: "int" },
+    { usage: "<foo:int...>", type: "int", multi: true },
   ])(
     "parses argument info with usage '$usage'",
     ({ usage, type, multi = false }) => {

--- a/brocolito/tests/examples.test.ts
+++ b/brocolito/tests/examples.test.ts
@@ -108,21 +108,21 @@ describe("Example commands", () => {
     await call("example");
 
     // then
-    expect(spy).toBeCalledWith({ someMore: false });
+    expect(spy).toHaveBeenCalledWith({ someMore: false });
 
     // when - called with no options
     spy.mockReset();
     await call("example -s");
 
     // then
-    expect(spy).toBeCalledWith({ someMore: true });
+    expect(spy).toHaveBeenCalledWith({ someMore: true });
 
     // when
     spy.mockReset();
     await call("example --test foo --some-more=false");
 
     // then
-    expect(spy).toBeCalledWith({ test: "foo", someMore: false });
+    expect(spy).toHaveBeenCalledWith({ test: "foo", someMore: false });
 
     // when - called with invalid options
     await expect(() => call("example --invalid=foo")).rejects.toThrow(
@@ -156,7 +156,7 @@ describe("Example commands", () => {
     await call("example -t foo");
 
     // then
-    expect(spy).toBeCalledWith({ test: "foo" });
+    expect(spy).toHaveBeenCalledWith({ test: "foo" });
   });
 
   it("using multi options", async () => {
@@ -173,19 +173,19 @@ describe("Example commands", () => {
     await call("example");
 
     // then
-    expect(spy).toBeCalledWith({ test: undefined });
+    expect(spy).toHaveBeenCalledWith({ test: undefined });
 
     // when - called with single entry
     await call("example --test foo --non-multi one --non-multi two");
 
     // then
-    expect(spy).toBeCalledWith({ test: ["foo"], nonMulti: "two" });
+    expect(spy).toHaveBeenCalledWith({ test: ["foo"], nonMulti: "two" });
 
     // when - called with multiple entries
     await call("example --test foo --test bar");
 
     // then
-    expect(spy).toBeCalledWith({ test: ["foo", "bar"] });
+    expect(spy).toHaveBeenCalledWith({ test: ["foo", "bar"] });
   });
 
   it("using union options", async () => {
@@ -202,7 +202,7 @@ describe("Example commands", () => {
     await call("example");
 
     // then
-    expect(spy).toBeCalledWith({});
+    expect(spy).toHaveBeenCalledWith({});
 
     // when - called with string not matching union constraints
     await expect(() => call("example --test bar")).rejects.toThrow(
@@ -213,7 +213,7 @@ describe("Example commands", () => {
     await call("example --test foo");
 
     // then
-    expect(spy).toBeCalledWith({ test: "foo" });
+    expect(spy).toHaveBeenCalledWith({ test: "foo" });
 
     // when - called with string not matching union constraints
     await expect(() =>
@@ -226,7 +226,7 @@ describe("Example commands", () => {
     await call("example --test-multi one --test-multi two");
 
     // then
-    expect(spy).toBeCalledWith({ testMulti: ["one", "two"] });
+    expect(spy).toHaveBeenCalledWith({ testMulti: ["one", "two"] });
   });
 
   it("using union args", async () => {
@@ -248,14 +248,14 @@ describe("Example commands", () => {
     await call("example foo");
 
     // then
-    expect(spy).toBeCalledWith({ test: "foo", testMulti: [] });
+    expect(spy).toHaveBeenCalledWith({ test: "foo", testMulti: [] });
 
     // when - called with single multi arg
     spy.mockReset();
     await call("example foo one");
 
     // then
-    expect(spy).toBeCalledWith({ test: "foo", testMulti: ["one"] });
+    expect(spy).toHaveBeenCalledWith({ test: "foo", testMulti: ["one"] });
 
     // when - called with string not matching union constraints
     await expect(() => call("example foo one ups")).rejects.toThrow(
@@ -267,10 +267,57 @@ describe("Example commands", () => {
     await call("example foo one two");
 
     // then
-    expect(spy).toBeCalledWith({
+    expect(spy).toHaveBeenCalledWith({
       test: "foo",
       testMulti: ["one", "two"],
     });
+  });
+
+  it("using int options and args", async () => {
+    // given
+    const spy = vi.fn();
+    CLI.command("example", "example-description")
+      .option("--count <int>", "an int")
+      .option("--scores <int...>", "multiple ints")
+      .arg("<ratio:int>", "an int arg")
+      .action(({ count, scores, ratio, ...rest }) =>
+        spy({ count, scores, ratio, ...rest }),
+      );
+
+    // when - called without int option
+    await call("example 5");
+
+    // then
+    expect(spy).toHaveBeenCalledWith({ ratio: 5 });
+
+    // when - called with int option
+    spy.mockReset();
+    await call("example --count 42 10");
+
+    // then
+    expect(spy).toHaveBeenCalledWith({ count: 42, ratio: 10 });
+
+    // when - called with multiple ints
+    spy.mockReset();
+    await call("example --scores 1 --scores 2 3");
+
+    // then
+    expect(spy).toHaveBeenCalledWith({ scores: [1, 2], ratio: 3 });
+
+    // when - called with invalid int
+    await expect(() => call("example --count abc 5")).rejects.toThrow(
+      'Invalid value "abc" provided for flag --count. Expected an integer.',
+    );
+
+    // when - called with invalid int arg
+    await expect(() => call("example abc")).rejects.toThrow(
+      'Invalid value "abc" provided for arg <ratio:int>. Expected an integer.',
+    );
+
+    // when - called with float
+    await expect(() => call("example --count 3.14 5")).rejects.toThrow(
+      'Invalid value "3.14" provided for flag --count. Expected an integer.',
+    );
   });
 
   it("parses args and options", async () => {
@@ -289,7 +336,7 @@ describe("Example commands", () => {
     await call("example ./some/path hot hotter lotta --test=ups --open");
 
     // then
-    expect(spy).toBeCalledWith({
+    expect(spy).toHaveBeenCalledWith({
       test: "ups",
       open: true,
       testArg: "./some/path",
@@ -300,7 +347,7 @@ describe("Example commands", () => {
     await call("example --open=false foo bar");
 
     // then
-    expect(spy).toBeCalledWith({
+    expect(spy).toHaveBeenCalledWith({
       testArg: "foo",
       testMulti: ["bar"],
       open: false,
@@ -330,13 +377,13 @@ describe("Example commands", () => {
     await call("example bar --open --test ups");
 
     // then
-    expect(barSpy).toBeCalledWith({ test: "ups", open: true });
+    expect(barSpy).toHaveBeenCalledWith({ test: "ups", open: true });
 
     // when - calling the sub command
     await call("example foo --open=false --nice ups");
 
     // then
-    expect(fooSpy).toBeCalledWith({ nice: "ups", open: false });
+    expect(fooSpy).toHaveBeenCalledWith({ nice: "ups", open: false });
   });
 
   it("parses subcommands, args and options", async () => {
@@ -357,7 +404,7 @@ describe("Example commands", () => {
     await call("example foo hot --nice try --open=false");
 
     // then
-    expect(subcommandSpy).toBeCalledWith({
+    expect(subcommandSpy).toHaveBeenCalledWith({
       what: "hot",
       open: false,
       nice: "try",


### PR DESCRIPTION
We want to be able to declare integer cli options so that we do not have to parse ourself inside the command logic.